### PR TITLE
add quick disambiguation fix with last step

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -86,6 +86,11 @@ process {
         ext.prefix       = { "${meta.id}.sorted" }
         ext.args         = " -n"
     }
+    if (params.step in ['filterconsensus']){
+        withName: 'SORTBAMDUPLEXCLEAN' {
+            ext.prefix       = { "${meta.id}.new.sorted" }
+        }
+    }
     withName: 'ASMINUSXS.*' {
         publishDir       = [
                                 mode: params.publish_dir_mode,


### PR DESCRIPTION
what happened is that the input filename of the SORTBAMDUPLEXCLEAN was called WHATEVER.sorted.bam and then the output was also called the same and this is problematic.
So I just changed that whenever the pipeline is run starting from the filterconsensus step the output filename is WHATEVER.new.sorted.bam so this does not conflict with anything.
