### PR TITLE
Compute coverage in provided global BED file

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -140,6 +140,9 @@ process {
     withName: 'DISCARDEDCOVERAGE.*' {
         ext.args         = "-mean"
     }
+    withName: 'COVERAGEGLOBAL' {
+        ext.args         = "-mean"
+    }
 
 
     withName: GROUPREADSBYUMIDUPLEX {

--- a/workflows/deepumicaller.nf
+++ b/workflows/deepumicaller.nf
@@ -98,6 +98,7 @@ include { SAMTOOLS_DEPTH                    as COMPUTEDEPTHHIGH            } fro
 
 include { BEDTOOLS_COVERAGE                 as DISCARDEDCOVERAGETARGETED   } from '../modules/nf-core/bedtools/coverage/main'
 include { BEDTOOLS_COVERAGE                 as DISCARDEDCOVERAGEGLOBAL     } from '../modules/nf-core/bedtools/coverage/main'
+include { BEDTOOLS_COVERAGE                 as COVERAGEGLOBAL              } from '../modules/nf-core/bedtools/coverage/main'
 
 
 // Versions and reports
@@ -495,8 +496,11 @@ workflow DEEPUMICALLER {
             // Quality check
             if (params.perform_qcs){
                 QUALIMAPQCMED(SORTBAMDUPLEXCONSMED.out.bam, params.targetsfile)
-                
                 ch_multiqc_files = ch_multiqc_files.mix(QUALIMAPQCMED.out.results.map{it[1]}.collect())
+                
+                SORTBAMDUPLEXCONSMED.out.bam.map{it -> [it[0], params.global_exons_file, it[1]]}.set { duplex_filt_bam_n_bed }
+                COVERAGEGLOBAL(duplex_filt_bam_n_bed, [])
+
             }
         }
 


### PR DESCRIPTION
- same BED file and strategy as for ASXS discarded reads


This PR aims to provide some information on possible off target coverage, in a simple and fast manner. This fully depends on the BED file that is provided as input and it will be the same as the one used for the AS-XS discarded reads coverage.

We could think of generating an updated version of the BED file we are currently using that comes from GENCODE annotations (including pseudogenes and other annotated regions instead of just protein coding exons as the current one)

## AI summary
This pull request introduces a new global coverage calculation step into the `DEEPUMICALLER` workflow. The main changes involve adding and configuring the `COVERAGEGLOBAL` process, which uses `BEDTOOLS_COVERAGE` to compute coverage across a global set of exons. This enhances the pipeline's quality control and reporting capabilities.

**Workflow enhancements:**

* Added a new process, `COVERAGEGLOBAL`, to the `DEEPUMICALLER` workflow for computing global exon coverage using `BEDTOOLS_COVERAGE`. [[1]](diffhunk://#diff-241c46f87568a31c993ffa746853235246911b9a108e7881e1c9ebd74d960c37R101) [[2]](diffhunk://#diff-241c46f87568a31c993ffa746853235246911b9a108e7881e1c9ebd74d960c37L498-R503)
* Configured the `COVERAGEGLOBAL` process in `modules.config` to use the `-mean` argument for summary statistics, matching the configuration of other coverage-related processes.

These changes improve the comprehensiveness of the coverage analysis in the workflow.