### PR TITLE
Use single confidence level for family metrics

### DIFF
--- a/bin/family_size_plots.py
+++ b/bin/family_size_plots.py
@@ -5,6 +5,7 @@ import pandas as pd
 import seaborn as sns
 import numpy as np
 import matplotlib.pyplot as plt
+import click
 
 
 def wrap_family_size_curves(data_sscs):
@@ -142,30 +143,27 @@ def compute_family_sizes_curve(sample, duplex_fam_data, prefix_figure, confidenc
 
 
 
-def stats_fam_size2plot(sample, duplex_metrics_file, output_prefix):
-
+def stats_fam_size2plot(sample, duplex_metrics_file, output_prefix, confidence = '4 2 2'):
+    
     # compute family size distributions from duplex stats data
     data_duplex_families = pd.read_table(f"{duplex_metrics_file}")
 
 
-    sample_data_high, data_family_size_curve_high = compute_family_sizes_curve(sample, data_duplex_families,
-                                                                                prefix_figure = output_prefix,
-                                                                                confidence = '6 3 3', confidence_name = 'high')
-    sample_data_med, data_family_size_curve_med = compute_family_sizes_curve(sample, data_duplex_families,
+    sample_data_duplex, data_family_size_curve_duplex = compute_family_sizes_curve(sample, data_duplex_families,
                                                                                     prefix_figure = output_prefix,
-                                                                                confidence = '4 2 2', confidence_name = 'med')
+                                                                                    confidence = confidence, confidence_name = 'duplex')
     sample_data_low, data_family_size_curve_low = compute_family_sizes_curve(sample, data_duplex_families, 
                                                                                     prefix_figure = output_prefix,
-                                                                                    confidence = '2 1 1', confidence_name = 'low')
+                                                                                    confidence = '2 1 1', confidence_name = 'allm')
 
-    sample_data = pd.concat((sample_data_high, sample_data_med, sample_data_low), axis = 0)
+    sample_data = pd.concat((sample_data_duplex, sample_data_low), axis = 0)
     sample_data.to_csv(f"{output_prefix}.sample_data.tsv",
                                     sep = "\t",
                                     header = True,
                                     index = False)
 
 
-    family_size_curve = pd.concat((data_family_size_curve_high, data_family_size_curve_med, data_family_size_curve_low), axis = 0)
+    family_size_curve = pd.concat((data_family_size_curve_duplex, data_family_size_curve_low), axis = 0)
     family_size_curve.to_csv(f"{output_prefix}.family_curve.tsv",
                                     sep = "\t",
                                     header = True,
@@ -174,11 +172,21 @@ def stats_fam_size2plot(sample, duplex_metrics_file, output_prefix):
     return 0
 
 
-sam = sys.argv[1]
-duplex_metrics_filee = sys.argv[2]
-output_file = sys.argv[3]
+@click.command()
+@click.option('--sample-name', '-n', required=True, type=str, help='Name of the sample.')
+@click.option('--input-file', '-i', required=True, type=click.Path(exists=True), help='Path to the input file.')
+@click.option('--output-file', '-o', required=True, type=click.Path(), help='Path to the output file.')
+@click.option('--confidence-level', '-c', default='4 2 2', show_default=True, type=str, help='Confidence level for the analysis.')
+def main(sample_name, input_file, output_file, confidence_level):
+    """
+    Main function to process the input file and generate plots.
+    """
 
-global limx
-limx = (0,50)
+    global limx
+    limx = (0,50)
 
-stats_fam_size2plot(sam, duplex_metrics_filee, output_file)
+    stats_fam_size2plot(sample_name, input_file, output_file, confidence=confidence_level)
+
+
+if __name__ == '__main__':
+    main()

--- a/bin/family_size_plots.py
+++ b/bin/family_size_plots.py
@@ -120,7 +120,7 @@ def compute_family_sizes_curve(sample, duplex_fam_data, prefix_figure, confidenc
 
 
 
-    keys = ['sample', 'quality', 'raw_reads',
+    keys = ['sample', 'quality', 'quality_threshold', 'raw_reads',
                 'duplicates', 'sscs', 'dscs',
                 'expected_dscs', 'recovery_of_dscs', 'unique_reads', 'uq_reads_duplex', 'unique_molecules',
                 'raw_x_dscs', 'raw_x_sscs', 'sscs_x_dscs',
@@ -128,7 +128,7 @@ def compute_family_sizes_curve(sample, duplex_fam_data, prefix_figure, confidenc
                 'noduplex_raw_reads', 'noduplex_sscs', 'noduplex_raw_x_sscs',
                 'peak_size']
 
-    values = [sample, confidence_name, total_reads,
+    values = [sample, confidence_name, confidence, total_reads,
                 round(percent_duplicates, 3), total_scss,
                 total_duplex,
                 expected_dscs, round(recovery_of_dscs, 3), unique_reads, round(total_duplex/unique_reads*100, 3), round(unique_reads/2),

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -209,6 +209,10 @@ process {
 //        ]
     }
 
+    withName: 'FAMILYMETRICS.*' {
+        ext.confidence      = params.filter_min_reads_duplex
+    }
+
 
     withName: 'CALLINGVARDICT.*' {
         ext.args         = params.vardict_params

--- a/modules/local/familymetrics/main.nf
+++ b/modules/local/familymetrics/main.nf
@@ -17,7 +17,7 @@ process FAMILYSIZEMETRICS {
     def prefix = task.ext.prefix ?: ""
     def sample_name = "${meta.id}"
     prefix = "${meta.id}${prefix}"
-    def confidence = task.ext.confidence ? "--confidence-level ${task.ext.confidence} " : ""
+    def confidence = task.ext.confidence ? "--confidence-level '${task.ext.confidence}' " : ""
     """
     family_size_plots.py \\
                 --sample-name ${sample_name} \\

--- a/modules/local/familymetrics/main.nf
+++ b/modules/local/familymetrics/main.nf
@@ -1,12 +1,8 @@
 process FAMILYSIZEMETRICS {
     tag "$meta.id"
     label 'process_medium'
-    
-    // TODO
-    // update this in the nfcore format once the container is available in biocontainers and galaxy singularity
-    conda "anaconda::seaborn=0.12.2"
-    container "biocontainers/seaborn:0.12.2_cv1"
 
+    container "docker.io/bbglab/deepcsa-core:0.0.1-alpha"
 
     input:
     tuple val(meta), path(duplex_metrics)
@@ -17,16 +13,17 @@ process FAMILYSIZEMETRICS {
     tuple val(meta), path("*.family_curve.tsv") , emit: curve_data
     path  "versions.yml"                        , topic: versions
 
-
     script:
     def prefix = task.ext.prefix ?: ""
     def sample_name = "${meta.id}"
     prefix = "${meta.id}${prefix}"
+    def confidence = task.ext.confidence ? "--confidence-level ${task.ext.confidence} " : ""
     """
     family_size_plots.py \\
-                ${sample_name} \\
-                ${prefix}.duplex_seq_metrics.duplex_family_sizes.txt \\
-                ${prefix}.family_sizes_plot_n_stats
+                --sample-name ${sample_name} \\
+                --input-file ${prefix}.duplex_seq_metrics.duplex_family_sizes.txt \\
+                --output-file ${prefix}.family_sizes_plot_n_stats \\
+                ${confidence}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
@@ -38,7 +35,7 @@ process FAMILYSIZEMETRICS {
     def prefix = task.ext.prefix ?: ""
     prefix = "${meta.id}${prefix}"
     """
-    touch ${prefix}.family_sizes_plot_n_stats.pdf \\ 
+    touch ${prefix}.family_sizes_plot_n_stats.pdf \ 
             ${prefix}.family_sizes_plot_n_stats.high.pdf
 
     cat <<-END_VERSIONS > versions.yml


### PR DESCRIPTION
Here we connect the familymetrics tool with the desired confidence levels defined in the nextflow parameters.

## AI summary
This pull request updates the `FAMILYSIZEMETRICS` process in the family metrics module to use a new container and improves parameter handling for confidence filtering. The main changes focus on modernizing the environment, making the process more configurable, and aligning the command-line interface with updated conventions.

**Environment and container updates:**

* Switched the process `FAMILYSIZEMETRICS` to use the `docker.io/bbglab/deepcsa-core:0.0.1-alpha` container instead of the previous `biocontainers/seaborn` and conda environment.

**Parameter and command improvements:**

* Added support for passing a confidence level to the process via the new `ext.confidence` parameter, which is set in the pipeline configuration for all `FAMILYMETRICS.*` processes.
* Updated the `family_size_plots.py` command invocation to use explicit flags (`--sample-name`, `--input-file`, `--output-file`) and conditionally include the `--confidence-level` argument if provided.

**Minor script and formatting fixes:**

* Fixed a minor formatting issue in the script where the `touch` command for output PDFs had an extra space.