### PR TITLE
fix calling parallel bug

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -141,10 +141,12 @@ process {
     }
 
     withName: 'DISCARDEDCOVERAGE.*' {
-        ext.args         = "-mean"
+        ext.args        = "-mean"
+        errorStrategy   = 'ignore'
     }
     withName: 'COVERAGEGLOBAL' {
-        ext.args         = "-mean"
+        ext.args        = "-mean"
+        errorStrategy   = 'ignore'
     }
 
 

--- a/modules/local/calling_vardict/main.nf
+++ b/modules/local/calling_vardict/main.nf
@@ -55,6 +55,8 @@ process CALLING_VARDICT {
 
     echo "Concatenated. teststrandbias running..."
 
+    pids=()
+
     for chunk in chunk_*.raw.tsv; do
         (
             cat \$chunk \
@@ -63,7 +65,22 @@ process CALLING_VARDICT {
                 -N ${prefix} $filter_args \
             > \${chunk}.genome.vcf
         ) &
+        pids+=(\$!)
     done
+
+    # Wait for all background jobs and check their exit codes
+    status=0
+    for pid in "\${pids[@]}"; do
+        if ! wait "\$pid"; then
+            echo "Error: process with PID \$pid failed." >&2
+            status=1
+        fi
+    done
+
+    if [ \$status -ne 0 ]; then
+        echo "One or more teststrandbias jobs failed. Aborting." >&2
+        exit 1
+    fi
     
     # Wait for all parallel processes to finish
     wait

--- a/modules/local/calling_vardict/main.nf
+++ b/modules/local/calling_vardict/main.nf
@@ -81,9 +81,6 @@ process CALLING_VARDICT {
         echo "One or more teststrandbias jobs failed. Aborting." >&2
         exit 1
     fi
-    
-    # Wait for all parallel processes to finish
-    wait
 
     echo "Done. Concatenating..."
 


### PR DESCRIPTION
- fix bug in parallel calling
- add ignore as errorstrategy for coverageglobal and other coverage processes

## AI generated summary
This pull request introduces improvements to error handling and job management in the pipeline configuration and the `CALLING_VARDICT` process. The main focus is on making the workflow more robust by ensuring that failed jobs are detected and handled appropriately, and by ignoring errors in specific coverage-related tasks.

**Error handling and job management enhancements:**

* Added tracking of background job PIDs and implemented logic to wait for all jobs, checking their exit codes. If any job fails, the process aborts with an error message. (`modules/local/calling_vardict/main.nf`) [[1]](diffhunk://#diff-2de3e5ec5a9ad83893a99409f89cd1ccb02aeb96a617f21cc8ce47402b07b1e8R58-R59) [[2]](diffhunk://#diff-2de3e5ec5a9ad83893a99409f89cd1ccb02aeb96a617f21cc8ce47402b07b1e8R68-R84)

**Configuration robustness:**

* Set `errorStrategy` to `'ignore'` for `DISCARDEDCOVERAGE.*` and `COVERAGEGLOBAL` processes to prevent pipeline failures due to errors in these steps. (`conf/modules.config`)