### PR TITLE
Report mutated reads per each mutation

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -252,9 +252,17 @@ process {
         ]
     }
 
-    withName: "PILEUPBAM.*|QUERYTABIX|BEDTOINTERVAL|READJUSTREGIONS|PATCH_DEPTH" {
+    withName: "PILEUPBAM.*|QUERYTABIX|BEDTOINTERVAL|READJUSTREGIONS" {
         publishDir       = [
                 enabled : false
+        ]
+    }
+
+    withName: "PATCH_DEPTH" {
+        publishDir = [
+            path: { "${params.outdir}/mutated_reads" },
+            mode: params.publish_dir_mode,
+            pattern: "*.mutated_reads.tsv.gz"
         ]
     }
 

--- a/modules/local/patchdepth/main.nf
+++ b/modules/local/patchdepth/main.nf
@@ -8,8 +8,9 @@ process PATCH_DEPTH {
     tuple val(meta), path(pileup_mutations), path(vcf)
 
     output:
-    tuple val(meta), path("*.readjusted.vcf")     , emit: patched_vcf
-    path  "versions.yml"                          , topic: versions
+    tuple val(meta), path("*.readjusted.vcf")       , emit: patched_vcf
+    tuple val(meta), path("*.mutated_reads.tsv.gz") , emit: mutated_reads
+    path  "versions.yml"                            , topic: versions
 
 
     script:
@@ -22,9 +23,9 @@ process PATCH_DEPTH {
     recompute_depth.py \\
             --mpileup-file ${pileup_mutations} \\
             --vcf-file ${vcf} \\
-            --output-filename ${prefix}.readjusted.vcf \\
+            --output-filename ${prefix}.readjusted \\
             ${suffix}
-            
+    gzip ${prefix}.readjusted.mutated_reads.tsv
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":


### PR DESCRIPTION
This branch has updates on the script responsible for recounting the mutations from the BAM file pileup in order to report the names of the specific reads with each mutation.

This could then be used for phasing mutations or identifying multiple independent occurrences of mutations, but for this we would probably have to know which reads do and which don't have the mutation... (it is not too difficult to implement...)

- [x] Pending to be tested in a real dataset and it would be good to check the file sizes.

## AI summary
This pull request updates the handling of output files for the `PATCH_DEPTH` process, improving the organization and publication of mutated reads data. The changes separate the publishing rules for `PATCH_DEPTH` from other processes and ensure that the mutated reads output is properly generated and published.

**Output publishing improvements:**

* The `PATCH_DEPTH` process now has a dedicated `publishDir` rule, publishing files matching `*.mutated_reads.tsv.gz` to the `${params.outdir}/mutated_reads` directory with the specified mode and pattern.
* The generic `publishDir` rule for processes no longer includes `PATCH_DEPTH`, preventing accidental suppression of its outputs.

**PATCH_DEPTH process output changes:**

* Added a new output tuple for the `PATCH_DEPTH` process to emit files matching `*.mutated_reads.tsv.gz` as `mutated_reads`.
* The script now gzips the `mutated_reads.tsv` file before output, ensuring compressed output for downstream use.
* The output filename for the readjusted VCF is now generated without the `.vcf` extension in the script, aligning with the expected output patterns.