### PR TITLE
Expand the sequencing panel internally

### DIFF
--- a/assets/multiqc_config.yml
+++ b/assets/multiqc_config.yml
@@ -11,6 +11,7 @@ extra_fn_clean_exts:
   - ".duplex"
   - ".raw"
   - ".all_molecules"
+  - ".final"
   - "_umi_histogram"
 
 export_plots: true
@@ -25,6 +26,7 @@ top_modules:
       path_filters_exclude:
         - "*.duplex/**"
         - "*.all_molecules/**"
+        - "*.final/**"
 
   - qualimap:
       name: "QualiMAP (all molecules)"
@@ -35,6 +37,7 @@ top_modules:
       path_filters_exclude:
         - "*.raw/**"
         - "*.duplex/**"
+        - "*.final/**"
 
   - qualimap:
       name: "QualiMAP (duplex)"
@@ -45,3 +48,15 @@ top_modules:
       path_filters_exclude:
         - "*.raw/**"
         - "*.all_molecules/**"
+        - "*.final/**"
+
+  - qualimap:
+      name: "QualiMAP (duplex on target only)"
+      info: "This section of the report shows QualiMAP results of the aligned set of duplex reads."
+      anchor: "qualimap_final"
+      path_filters:
+        - "*.final/**"
+      path_filters_exclude:
+        - "*.raw/**"
+        - "*.all_molecules/**"
+        - "*.duplex/**"

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -136,6 +136,9 @@ process {
     withName: 'QUALIMAPQCDUPLEX' {
         ext.prefix       = { ".duplex" }
     }
+    withName: 'QUALIMAPQCFINAL' {
+        ext.prefix       = { ".final" }
+    }
 
     withName: 'DISCARDEDCOVERAGE.*' {
         ext.args        = "-mean"

--- a/conf/results_outputs.config
+++ b/conf/results_outputs.config
@@ -49,6 +49,13 @@ process {
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
+    withName: 'QUALIMAPQCFINAL' {
+        publishDir = [
+            path: { "${params.outdir}/metrics/coverage_n_depth/duplex/qualimapqc_final" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
 
     withName: 'DISCARDEDCOVERAGEGLOBAL' {
         publishDir = [

--- a/modules/local/expand_regions/main.nf
+++ b/modules/local/expand_regions/main.nf
@@ -1,0 +1,54 @@
+process EXPAND_PANEL {
+    tag "$meta.id"
+    label 'postprocess_compute'
+
+    conda "bioconda::tabix=1.11"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/tabix:1.11--hdfd78af_0' :
+        'biocontainers/tabix:1.11--hdfd78af_0' }"
+
+    input:
+    tuple val(meta), path(bedfile)
+
+    output:
+    tuple val(meta), path("*expanded.bed") , emit: expanded_bed
+    path  "versions.yml"                   , topic: versions
+
+
+    script:
+    def prefix = task.ext.prefix ?: ""
+    prefix = "${meta.id}${prefix}"
+    """
+    awk -v OFS='\\t' '{\$2=\$2-250;\$3=\$3+250;print \$0}' ${bedfile} > ${prefix}.expanded250.bed6.bed
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        tabix: \$(echo \$(tabix -h 2>&1) | sed 's/^.*Version: //; s/ .*\$//')
+    END_VERSIONS
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: ""
+    prefix = "${meta.id}${prefix}"
+    """
+    touch ${prefix}.expanded250.bed6.bed;
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        tabix: \$(echo \$(tabix -h 2>&1) | sed 's/^.*Version: //; s/ .*\$//')
+    END_VERSIONS
+    """
+}
+
+// tabix -s 1 -b 2 -e 2 ${prefix}.Ns_per_position.tsv.gz;
+// tabix: \$(echo \$(tabix --version 2>&1) | sed 's/^.*tabix (htslib) //; s/Copyright.*\$//')
+// zcat $pileup | \\
+//         awk 'BEGIN{FS=OFS="\\t"} {print \$1"\\t"\$2"\\t"gsub(/N/,"",\$5)"\\t"gsub(/n/,"",\$5)}' | \\
+//         awk '{\$3=\$3+\$4; print \$1"\\t"\$2"\\t"\$3}' | \\
+//         bgzip | \\
+//         > ${prefix}.Ns_per_position.tsv.gz
+
+// bedtools intersect -u -a <(zcat $MPILEUP_PATH/$SAMPLE.mpileup_out.tsv.gz |
+//                             awk 'BEGIN{FS=OFS="\t"} {print $1"\t"$2"\t"$4"\t"gsub(/N/,"",$5)"\t"gsub(/n/,"",$5)}' |
+//                             awk '{$4=$4+$5; print $1"\t"$2"\t"$2"\t"$3"\t"$4}') -b $BED_FILE |
+//                             gzip > $N_DEPTH_PATH/$SAMPLE.high.Ns_per_position.tsv.gz

--- a/modules/local/expand_regions/main.nf
+++ b/modules/local/expand_regions/main.nf
@@ -11,15 +11,15 @@ process EXPAND_PANEL {
     tuple val(meta), path(bedfile)
 
     output:
-    tuple val(meta), path("*expanded.bed") , emit: expanded_bed
-    path  "versions.yml"                   , topic: versions
+    tuple val(meta), path("*expanded250.bed") , emit: expanded_bed
+    path  "versions.yml"                      , topic: versions
 
 
     script:
     def prefix = task.ext.prefix ?: ""
     prefix = "${meta.id}${prefix}"
     """
-    awk -v OFS='\\t' '{\$2=\$2-250;\$3=\$3+250;print \$0}' ${bedfile} > ${prefix}.expanded250.bed6.bed
+    awk -v OFS='\\t' '{\$2=\$2-250;\$3=\$3+250;print \$0}' ${bedfile} > ${prefix}.expanded250.bed
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
@@ -31,7 +31,7 @@ process EXPAND_PANEL {
     def prefix = task.ext.prefix ?: ""
     prefix = "${meta.id}${prefix}"
     """
-    touch ${prefix}.expanded250.bed6.bed;
+    touch ${prefix}.expanded250.bed;
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
@@ -39,16 +39,3 @@ process EXPAND_PANEL {
     END_VERSIONS
     """
 }
-
-// tabix -s 1 -b 2 -e 2 ${prefix}.Ns_per_position.tsv.gz;
-// tabix: \$(echo \$(tabix --version 2>&1) | sed 's/^.*tabix (htslib) //; s/Copyright.*\$//')
-// zcat $pileup | \\
-//         awk 'BEGIN{FS=OFS="\\t"} {print \$1"\\t"\$2"\\t"gsub(/N/,"",\$5)"\\t"gsub(/n/,"",\$5)}' | \\
-//         awk '{\$3=\$3+\$4; print \$1"\\t"\$2"\\t"\$3}' | \\
-//         bgzip | \\
-//         > ${prefix}.Ns_per_position.tsv.gz
-
-// bedtools intersect -u -a <(zcat $MPILEUP_PATH/$SAMPLE.mpileup_out.tsv.gz |
-//                             awk 'BEGIN{FS=OFS="\t"} {print $1"\t"$2"\t"$4"\t"gsub(/N/,"",$5)"\t"gsub(/n/,"",$5)}' |
-//                             awk '{$4=$4+$5; print $1"\t"$2"\t"$2"\t"$3"\t"$4}') -b $BED_FILE |
-//                             gzip > $N_DEPTH_PATH/$SAMPLE.high.Ns_per_position.tsv.gz

--- a/workflows/deepumicaller.nf
+++ b/workflows/deepumicaller.nf
@@ -20,6 +20,8 @@ include { process_bams              } from '../modules/local/utils'
 //
 include { INPUT_CHECK                                                           } from '../subworkflows/local/input_check'
 
+include { EXPAND_PANEL                                                          } from '../modules/local/expand_regions/main'
+
 include { SPLITFASTQ                                                            } from '../modules/local/splitfastq/main'
 
 include { FGBIO_FASTQTOBAM                  as FASTQTOBAM                       } from '../modules/local/fgbio/fastqtobam/main'
@@ -144,12 +146,13 @@ workflow DEEPUMICALLER {
    
 
     // Create value channels for targets and global exons files (if provided)
-    ch_targetsfile = params.targetsfile ? file(params.targetsfile, checkIfExists: true) : channel.empty()
-    ch_global_exons_file = params.global_exons_file ? file(params.global_exons_file, checkIfExists: true) : file(params.targetsfile, checkIfExists: true)
+    EXPAND_PANEL(
+        channel.of([ [ id:"${file(params.targetsfile).getSimpleName()}" ], params.targetsfile ])
+    )
+    ch_targetsfile = EXPAND_PANEL.out.expanded_bed.first().map{it -> it[1]}
+    ch_global_exons_file = params.global_exons_file ? file(params.global_exons_file, checkIfExists: true) : ch_targetsfile.first()
 
-
-    targets_bed = channel.of([ [ id:"${file(params.targetsfile).getSimpleName()}" ], ch_targetsfile ])
-    BEDTOINTERVAL(targets_bed, ch_ref_fasta_dict, [])
+    BEDTOINTERVAL(EXPAND_PANEL.out.expanded_bed, ch_ref_fasta_dict, [])
 
 
     
@@ -488,7 +491,7 @@ workflow DEEPUMICALLER {
 
         if (params.perform_qcs){
             // requires input coordinate sorted
-            QUALIMAPQCALLMOLECULES(SORTBAMAMHQ.out.bam, params.targetsfile)
+            QUALIMAPQCALLMOLECULES(SORTBAMAMHQ.out.bam, ch_targetsfile)
             ch_multiqc_files = ch_multiqc_files.mix(QUALIMAPQCALLMOLECULES.out.results.map{it -> it[1]}.collect())
         }
 
@@ -518,8 +521,8 @@ workflow DEEPUMICALLER {
 
             SORTBAMDUPLEXCONS.out.bam.map{it -> [it[0], ch_global_exons_file, it[1]]}.set { duplex_filt_bam_n_globalbed }
             COVERAGEGLOBAL(duplex_filt_bam_n_globalbed, [])
-            
-            SORTBAMDUPLEXCONS.out.bam.map{it -> [it[0], ch_targetsfile, it[1]]}.set { duplex_filt_bam_n_targetedbed }
+
+            SORTBAMDUPLEXCONS.out.bam.map{it -> [it[0], params.targetsfile, it[1]]}.set { duplex_filt_bam_n_targetedbed }
             COVERAGETARGETED(duplex_filt_bam_n_targetedbed, [])
 
             // MULTIQCDUPLEX: Early report with accumulated QC files (no software versions yet)

--- a/workflows/deepumicaller.nf
+++ b/workflows/deepumicaller.nf
@@ -146,8 +146,9 @@ workflow DEEPUMICALLER {
    
 
     // Create value channels for targets and global exons files (if provided)
+    original_targetsfile = file(params.targetsfile, checkIfExists: true)
     EXPAND_PANEL(
-        channel.of([ [ id:"${file(params.targetsfile).getSimpleName()}" ], params.targetsfile ])
+        channel.of([ [ id:"${original_targetsfile.getSimpleName()}" ], original_targetsfile ])
     )
     ch_targetsfile = EXPAND_PANEL.out.expanded_bed.first().map{it -> it[1]}
     ch_global_exons_file = params.global_exons_file ? file(params.global_exons_file, checkIfExists: true) : ch_targetsfile.first()
@@ -436,7 +437,7 @@ workflow DEEPUMICALLER {
             .map { meta, bam -> "sample,bam,parent_dna\n${meta.id},${params.outdir}/processing_files/all_molecules_reads_bam/${bam.name},${meta.parent_dna}\n" }
             .collectFile(name: 'samplesheet_bam_filtered_inputs.csv', storeDir: "${params.outdir}/pipeline_info", skip: 1, keepHeader: true)
 
-        ASMINUSXS.out.discarded_bam.map{it -> [it[0], ch_targetsfile, it[1]]}.set { discarded_bam_targeted }
+        ASMINUSXS.out.discarded_bam.map{it -> [it[0], original_targetsfile, it[1]]}.set { discarded_bam_targeted }
         DISCARDEDCOVERAGETARGETED(discarded_bam_targeted, [])
 
         ASMINUSXS.out.discarded_bam.map{it -> [it[0], ch_global_exons_file, it[1]]}.set { discarded_bam }
@@ -491,7 +492,7 @@ workflow DEEPUMICALLER {
 
         if (params.perform_qcs){
             // requires input coordinate sorted
-            QUALIMAPQCALLMOLECULES(SORTBAMAMHQ.out.bam, ch_targetsfile)
+            QUALIMAPQCALLMOLECULES(SORTBAMAMHQ.out.bam, original_targetsfile)
             ch_multiqc_files = ch_multiqc_files.mix(QUALIMAPQCALLMOLECULES.out.results.map{it -> it[1]}.collect())
         }
 
@@ -516,13 +517,13 @@ workflow DEEPUMICALLER {
 
         // Quality check
         if (params.perform_qcs){
-            QUALIMAPQCDUPLEX(SORTBAMDUPLEXCONS.out.bam, ch_targetsfile)
+            QUALIMAPQCDUPLEX(SORTBAMDUPLEXCONS.out.bam, original_targetsfile)
             ch_multiqc_files = ch_multiqc_files.mix(QUALIMAPQCDUPLEX.out.results.map{it -> it[1]}.collect())
 
             SORTBAMDUPLEXCONS.out.bam.map{it -> [it[0], ch_global_exons_file, it[1]]}.set { duplex_filt_bam_n_globalbed }
             COVERAGEGLOBAL(duplex_filt_bam_n_globalbed, [])
 
-            SORTBAMDUPLEXCONS.out.bam.map{it -> [it[0], params.targetsfile, it[1]]}.set { duplex_filt_bam_n_targetedbed }
+            SORTBAMDUPLEXCONS.out.bam.map{it -> [it[0], original_targetsfile, it[1]]}.set { duplex_filt_bam_n_targetedbed }
             COVERAGETARGETED(duplex_filt_bam_n_targetedbed, [])
 
             // MULTIQCDUPLEX: Early report with accumulated QC files (no software versions yet)

--- a/workflows/deepumicaller.nf
+++ b/workflows/deepumicaller.nf
@@ -80,6 +80,7 @@ include { PICARD_BEDTOINTERVALLIST          as BEDTOINTERVAL               } fro
 include { QUALIMAP_BAMQC                    as QUALIMAPQCRAW               } from '../modules/nf-core/qualimap/bamqc/main'
 include { QUALIMAP_BAMQC                    as QUALIMAPQCALLMOLECULES      } from '../modules/nf-core/qualimap/bamqc/main'
 include { QUALIMAP_BAMQC                    as QUALIMAPQCDUPLEX            } from '../modules/nf-core/qualimap/bamqc/main'
+include { QUALIMAP_BAMQC                    as QUALIMAPQCFINAL             } from '../modules/nf-core/qualimap/bamqc/main'
 
 
 include { SAMTOOLS_DEPTH                    as COMPUTEDEPTH                 } from '../modules/nf-core/samtools/depth/main'
@@ -492,7 +493,7 @@ workflow DEEPUMICALLER {
 
         if (params.perform_qcs){
             // requires input coordinate sorted
-            QUALIMAPQCALLMOLECULES(SORTBAMAMHQ.out.bam, original_targetsfile)
+            QUALIMAPQCALLMOLECULES(SORTBAMAMHQ.out.bam, ch_targetsfile)
             ch_multiqc_files = ch_multiqc_files.mix(QUALIMAPQCALLMOLECULES.out.results.map{it -> it[1]}.collect())
         }
 
@@ -517,8 +518,11 @@ workflow DEEPUMICALLER {
 
         // Quality check
         if (params.perform_qcs){
-            QUALIMAPQCDUPLEX(SORTBAMDUPLEXCONS.out.bam, original_targetsfile)
+            QUALIMAPQCDUPLEX(SORTBAMDUPLEXCONS.out.bam, ch_targetsfile)
             ch_multiqc_files = ch_multiqc_files.mix(QUALIMAPQCDUPLEX.out.results.map{it -> it[1]}.collect())
+
+            QUALIMAPQCFINAL(SORTBAMDUPLEXCONS.out.bam, original_targetsfile)
+            ch_multiqc_files = ch_multiqc_files.mix(QUALIMAPQCFINAL.out.results.map{it -> it[1]}.collect())
 
             SORTBAMDUPLEXCONS.out.bam.map{it -> [it[0], ch_global_exons_file, it[1]]}.set { duplex_filt_bam_n_globalbed }
             COVERAGEGLOBAL(duplex_filt_bam_n_globalbed, [])


### PR DESCRIPTION
This update enables an updated computation of the sequencing depth while keeping the same logic for the rest of the metrics.

- [ ] agree on the precise reporting of each of the metrics
- [ ] test that it work well and that the output is parseable by the metrics scripts