### PR TITLE
feat: enable internal FASTQ splitting via seqkit split2

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -115,6 +115,12 @@ process {
         cpus = { 1 * task.attempt }
         memory = { 3.GB * task.attempt }
     }
+
+    // Processes: SPLITFASTQ
+    withName: 'SPLITFASTQ' {
+        cpus   = { 8 * task.attempt }
+        memory = { 8.GB * task.attempt }
+    }
     
     // Processes: PICARD_BEDTOINTERVALLIST, SAMPLESHEET_CHECK
     withLabel: 'genomic_prep' {

--- a/docs/input_scenarios.md
+++ b/docs/input_scenarios.md
@@ -184,9 +184,28 @@ Here we list two possibilities for speeding up the processing of the duplex read
 
 ### Split input FASTQs
 
-If the input FASTQs are very big, this will result in long execution times of the first read preprocessing steps. Having the input split across multiple FASTQ files for the same sample will speed up the execution of this steps, or help solve resource-related issues.
+If the input FASTQs are very big, this will result in long execution times of the first read preprocessing steps. Having the input split across multiple FASTQ files for the same sample will speed up the execution of these steps, or help solve resource-related issues.
 
-We are working to allow the user split the FASTQs within deepUMIcaller, but as of now this is not an option.
+**Use Case**: An individual FASTQ pair (R1/R2) is larger than ~20GB (~320M reads).
+
+**Any Input Structure** + Performance Parameters:
+
+```bash
+  --run_splitfastq true \
+  --splitfastq_parts 5
+```
+
+**Guideline**: aim to split so that each resulting FASTQ chunk is around 20GB (~320M reads) — e.g. a 100GB FASTQ pair should use `splitfastq_parts: 5`. FASTQ pairs already at or below this size don't need to be split.
+
+**Note**: this is independent from, and composable with, having [multiple FASTQ rows for the same sample](#2-multiple-fastqs-for-the-same-sample-same-duplex-sequencing-library) (e.g. multiple lanes) — internal splitting is applied per input row, and all resulting parts are automatically merged back before UMI grouping regardless of whether the split happened at the sequencer/upstream or internally in deepUMIcaller.
+
+**Benefits:**
+
+- Parallel processing of large FASTQ inputs
+- Reduced per-chunk runtime and memory requirements
+- Same final results as non-split processing
+
+**Compatible with all input scenarios above.**
 
 ## Intermediate Step Entry Points
 

--- a/modules/local/splitfastq/main.nf
+++ b/modules/local/splitfastq/main.nf
@@ -21,8 +21,7 @@ process SPLITFASTQ {
     def read1 = fastqs[0]
     def read2 = fastqs[1]  // assume second read exists
 
-    // Only check workflow parameter, default to 10
-    def split_parts = params.splitfastq_parts ?: 10
+    def split_parts = params.splitfastq_parts
 
     """
     mkdir -p split_fastq

--- a/modules/local/splitfastq/main.nf
+++ b/modules/local/splitfastq/main.nf
@@ -13,9 +13,6 @@ process SPLITFASTQ {
     tuple val(meta),  path("**/*.gz"), emit: split_fastqs
     path "versions.yml", emit: versions
 
-    when:
-    task.ext.when == null || task.ext.when
-
     script:
     def args = task.ext.args ?: ''
     def read1 = fastqs[0]

--- a/modules/local/splitfastq/main.nf
+++ b/modules/local/splitfastq/main.nf
@@ -21,8 +21,8 @@ process SPLITFASTQ {
     def read1 = fastqs[0]
     def read2 = fastqs[1]  // assume second read exists
 
-    // Only check workflow parameter, default to 20
-    def split_parts = params.splitfastq_parts ?: 20
+    // Only check workflow parameter, default to 10
+    def split_parts = params.splitfastq_parts ?: 10
 
     """
     mkdir -p split_fastq

--- a/modules/local/splitfastq/main.nf
+++ b/modules/local/splitfastq/main.nf
@@ -25,7 +25,7 @@ process SPLITFASTQ {
 
     """
     mkdir -p split_fastq
-    seqkit split2 -p ${split_parts} -O split_fastq $args -1 ${read1} -2 ${read2}
+    seqkit split2 -p ${split_parts} -j ${task.cpus} -O split_fastq $args -1 ${read1} -2 ${read2}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -78,13 +78,15 @@
                 "run_splitfastq": {
                     "type": "boolean",
                     "fa_icon": "fas fa-dna",
-                    "description": "Enable splitting of FASTQ files into parts for parallelisation."
+                    "description": "Enable splitting of FASTQ files into parts for parallelisation.",
+                    "help_text": "Recommended when an individual FASTQ pair (R1/R2) is larger than ~20GB (~320M reads), as this can lead to long runtimes and high memory usage in the early read preprocessing steps. Split parts are automatically merged back before UMI grouping, so final results are unaffected."
                 },
                 "splitfastq_parts": {
                     "type": "integer",
                     "fa_icon": "fas fa-dna",
                     "description": "Number of parts to split FASTQ files into.",
-                    "default": 5
+                    "default": 5,
+                    "help_text": "Choose a number of parts so that each resulting split FASTQ file (R1/R2) is around 20GB (~320M reads), which keeps per-chunk runtime and memory usage manageable. For example, for a 100GB FASTQ pair use splitfastq_parts: 5."
                 },
                 "split_by_chrom": {
                     "type": "boolean",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -78,15 +78,13 @@
                 "run_splitfastq": {
                     "type": "boolean",
                     "fa_icon": "fas fa-dna",
-                    "description": "Enable splitting of FASTQ files.",
-                    "hidden": true
+                    "description": "Enable splitting of FASTQ files into parts for parallelisation."
                 },
                 "splitfastq_parts": {
                     "type": "integer",
                     "fa_icon": "fas fa-dna",
                     "description": "Number of parts to split FASTQ files into.",
-                    "default": 5,
-                    "hidden": true
+                    "default": 5
                 },
                 "split_by_chrom": {
                     "type": "boolean",

--- a/tests/main.nf.test
+++ b/tests/main.nf.test
@@ -110,7 +110,66 @@ nextflow_pipeline {
 
     /*
     ========================================================================================
-        TEST 2: PERFORMANCE OPTIMIZATION - Chromosome-based Parallelization
+        TEST 2: FASTQ SPLITTING - Internal parallelisation via seqkit split2
+    ========================================================================================
+    Purpose: Validates that internal FASTQ splitting produces identical results to TEST 1
+
+    Input: Same single FASTQ pair as Test 1
+    Parameters:
+        - run_splitfastq = true  (split FASTQs internally before mapping)
+        - splitfastq_parts = 2   (split into 2 parts)
+
+    Expected Behavior:
+        - Pipeline splits each FASTQ into 2 parts via seqkit split2
+        - Each part is processed independently through mapping
+        - Parts are merged back per sample before UMI grouping
+        - Final VCF is identical to TEST 1 (splitting is transparent)
+
+    Success Criteria: VCF precision ≥99% vs reference (same reference as TEST 1)
+    ========================================================================================
+    */
+    test("TEST 2. FASTQ splitting - internal parallelisation via seqkit") {
+        tag "split_fastq"
+
+        when {
+            params {
+                input            = "${projectDir}/tests/test_data/input/input_test.csv"
+                outdir           = "${outputDir}/tests_results_splitfastq/"
+                run_splitfastq   = true
+                splitfastq_parts = 2
+            }
+        }
+        then {
+            assert workflow.success : "Pipeline should complete without errors"
+
+            def currentDir = file("${params.outdir}/processing_files/callingvardictduplex")
+            def expectedDir = file("tests/test_data/expected_output")
+            def currentVcfs = currentDir.listFiles().findAll { it.name.endsWith('.vcf') }
+            assert currentVcfs.size() > 0 : "VALIDATION ERROR: No VCF files generated in output directory: ${currentDir}"
+
+            currentVcfs.each { currentVcf ->
+                def expectedVcf = new File(expectedDir, currentVcf.name)
+                assert expectedVcf.exists() : "REFERENCE ERROR: Expected reference file missing: ${expectedVcf.name}"
+
+                def scriptPath = new File("${projectDir}/bin/test_utilities/compare_vcfs_detailed.py")
+                assert scriptPath.exists() : "SCRIPT ERROR: Comparison script not found at ${scriptPath}"
+                def cmd = "python3 ${scriptPath} ${currentVcf} ${expectedVcf}"
+                def proc = cmd.execute()
+                proc.waitFor()
+                def output = proc.in.text.trim()
+                assert proc.exitValue() == 0 : "COMPARISON SCRIPT ERROR: compare_vcfs_detailed.py failed for ${currentVcf.name} with exit code ${proc.exitValue()}. Error: ${proc.err.text}"
+                assert output.isNumber() : "COMPARISON SCRIPT ERROR: Non-numeric output from compare_vcfs_detailed.py for ${currentVcf.name}: '${output}'"
+                def precision = output as Double
+
+                println "\n[TEST 2 - SPLIT FASTQ] VCF precision for ${currentVcf.name}: ${precision}%"
+                assert precision >= 99.0 : "PRECISION FAILURE: VCF ${currentVcf.name} precision ${precision}% below 99% threshold"
+            }
+        }
+    }
+
+    /*
+    ========================================================================================
+        TEST 3: PERFORMANCE OPTIMIZATION - Chromosome-based Parallelization
     ========================================================================================
     Purpose: Validates pipeline performance optimization through chromosome splitting
     
@@ -129,7 +188,7 @@ nextflow_pipeline {
         - Results identical to Test 1 (validates splitting correctness)
     ========================================================================================
     */
-    test("TEST 2. Performance optimization - chromosome-based parallelization") {
+    test("TEST 3. Performance optimization - chromosome-based parallelization") {
         tag "split_by_chrom"
 
         when {
@@ -170,7 +229,7 @@ nextflow_pipeline {
                 assert output.isNumber() : "COMPARISON SCRIPT ERROR: Non-numeric output from compare_vcfs_detailed.py for ${currentVcf.name}: '${output}'"
                 def precision = output as Double
 
-                println "\n[TEST 2 - CHROMOSOME SPLITTING] VCF precision for ${currentVcf.name}: ${precision}%"
+                println "\n[TEST 3 - CHROMOSOME SPLITTING] VCF precision for ${currentVcf.name}: ${precision}%"
                 assert precision >= 99.0 : "PRECISION FAILURE: VCF ${currentVcf.name} precision ${precision}% below 99% threshold"
             }
         }
@@ -178,7 +237,7 @@ nextflow_pipeline {
 
     /*
     ========================================================================================
-        TEST 3: TECHNICAL REPLICATES - Multi-file Sample Processing
+        TEST 4: TECHNICAL REPLICATES - Multi-file Sample Processing
     ========================================================================================
     Purpose: Validates handling of technical replicates (multiple sequencing lanes)
     
@@ -200,7 +259,7 @@ nextflow_pipeline {
     Success Criteria: VCF precision ≥99% vs reference
     ========================================================================================
     */
-    test("TEST 3. Technical replicates - multi-file sample processing") {
+    test("TEST 4. Technical replicates - multi-file sample processing") {
         tag "multi-file"
 
         when {
@@ -239,7 +298,7 @@ nextflow_pipeline {
                 assert output.isNumber() : "COMPARISON SCRIPT ERROR: Non-numeric output from compare_vcfs_detailed.py for ${currentVcf.name}: '${output}'"
                 def precision = output as Double
 
-                println "\n[TEST 3 - TECHNICAL REPLICATES] VCF precision for ${currentVcf.name}: ${precision}%"
+                println "\n[TEST 4 - TECHNICAL REPLICATES] VCF precision for ${currentVcf.name}: ${precision}%"
                 assert precision >= 99.0 : "PRECISION FAILURE: VCF ${currentVcf.name} precision ${precision}% below 99% threshold"
             }
         }
@@ -247,7 +306,7 @@ nextflow_pipeline {
 
     /*
     ========================================================================================
-        TEST 4: BIOLOGICAL REPLICATES - Multi-sample Patient Processing
+        TEST 5: BIOLOGICAL REPLICATES - Multi-sample Patient Processing
     ========================================================================================
     Purpose: Validates patient-level aggregation across multiple biological samples
     
@@ -269,7 +328,7 @@ nextflow_pipeline {
     Success Criteria: VCF precision ≥99% vs reference
     ========================================================================================
     */
-    test("TEST 4. Biological replicates - multi-sample patient processing") {
+    test("TEST 5. Biological replicates - multi-sample patient processing") {
         tag "multi-sample"
 
         when {
@@ -309,7 +368,7 @@ nextflow_pipeline {
                 assert output.isNumber() : "COMPARISON SCRIPT ERROR: Non-numeric output from compare_vcfs_detailed.py for ${currentVcf.name}: '${output}'"
                 def precision = output as Double
 
-                println "\n[TEST 4 - BIOLOGICAL REPLICATES] VCF precision for ${currentVcf.name}: ${precision}%"
+                println "\n[TEST 5 - BIOLOGICAL REPLICATES] VCF precision for ${currentVcf.name}: ${precision}%"
                 assert precision >= 99.0 : "PRECISION FAILURE: VCF ${currentVcf.name} precision ${precision}% below 99% threshold"
             }
         }
@@ -318,7 +377,7 @@ nextflow_pipeline {
 
     /*
     ========================================================================================
-        TEST 5: COMPREHENSIVE SCENARIO - Complete Multi-level Processing
+        TEST 6: COMPREHENSIVE SCENARIO - Complete Multi-level Processing
     ========================================================================================
     Purpose: Validates the most complex scenario combining all processing modes
     
@@ -346,7 +405,7 @@ nextflow_pipeline {
     Note: This is the most computationally intensive test
     ========================================================================================
     */
-    test("TEST 5. Comprehensive scenario - complete multi-level processing") {
+    test("TEST 6. Comprehensive scenario - complete multi-level processing") {
         tag "multiAll"
 
         when {
@@ -388,7 +447,7 @@ nextflow_pipeline {
                 assert output.isNumber() : "COMPARISON SCRIPT ERROR: Non-numeric output from compare_vcfs_detailed.py for ${currentVcf.name}: '${output}'"
                 def precision = output as Double
 
-                println "\n[TEST 5 - COMPREHENSIVE SCENARIO] VCF precision for ${currentVcf.name}: ${precision}%"
+                println "\n[TEST 6 - COMPREHENSIVE SCENARIO] VCF precision for ${currentVcf.name}: ${precision}%"
                 assert precision >= 99.0 : "PRECISION FAILURE: VCF ${currentVcf.name} precision ${precision}% below 99% threshold"
             }
         }
@@ -396,7 +455,7 @@ nextflow_pipeline {
 
     /*
     ========================================================================================
-        TEST 6: INTERMEDIATE STEP - GroupReadsByUmi Step Entry Point
+        TEST 7: INTERMEDIATE STEP - GroupReadsByUmi Step Entry Point
     ========================================================================================
     Purpose: Validates pipeline functionality starting from the groupreadsbyumi step
     
@@ -423,7 +482,7 @@ nextflow_pipeline {
     Success Criteria: VCF precision ≥99% vs reference
     ========================================================================================
     */
-    test("TEST 6. Intermediate step - GroupByUmi entry point") {
+    test("TEST 7. Intermediate step - GroupByUmi entry point") {
         tag "groupreadsbyumi"
 
         when {
@@ -468,7 +527,7 @@ nextflow_pipeline {
                 assert output.isNumber() : "COMPARISON SCRIPT ERROR: Non-numeric output from compare_vcfs_detailed.py for ${currentVcf.name}: '${output}'"
                 def precision = output as Double
 
-                println "\n[TEST 6 - GROUPREADSBYUMI STEP] VCF precision for ${currentVcf.name}: ${precision}%"
+                println "\n[TEST 7 - GROUPREADSBYUMI STEP] VCF precision for ${currentVcf.name}: ${precision}%"
                 assert precision >= 99.0 : "PRECISION FAILURE: VCF ${currentVcf.name} precision ${precision}% below 99% threshold"
             }
         }
@@ -476,7 +535,7 @@ nextflow_pipeline {
 
     /*
     ========================================================================================
-        TEST 7: INTERMEDIATE STEP - FilterConsensus Step Entry Point
+        TEST 8: INTERMEDIATE STEP - FilterConsensus Step Entry Point
     ========================================================================================
     Purpose: Validates pipeline functionality starting from the filterconsensus step
     
@@ -503,7 +562,7 @@ nextflow_pipeline {
     Success Criteria: VCF precision ≥99% vs reference
     ========================================================================================
     */
-    test("TEST 7. Intermediate step - FilterConsensus entry point") {
+    test("TEST 8. Intermediate step - FilterConsensus entry point") {
         tag "filterconsensus"
 
         when {
@@ -548,7 +607,7 @@ nextflow_pipeline {
                 assert output.isNumber() : "COMPARISON SCRIPT ERROR: Non-numeric output from compare_vcfs_detailed.py for ${currentVcf.name}: '${output}'"
                 def precision = output as Double
 
-                println "\n[TEST 7 - FILTERCONSENSUS STEP] VCF precision for ${currentVcf.name}: ${precision}%"
+                println "\n[TEST 8 - FILTERCONSENSUS STEP] VCF precision for ${currentVcf.name}: ${precision}%"
                 assert precision >= 99.0 : "PRECISION FAILURE: VCF ${currentVcf.name} precision ${precision}% below 99% threshold"
             }
         }
@@ -556,7 +615,7 @@ nextflow_pipeline {
 
     /*
     ========================================================================================
-        TEST 8: INTERMEDIATE STEP - Calling Step Entry Point
+        TEST 9: INTERMEDIATE STEP - Calling Step Entry Point
     ========================================================================================
     Purpose: Validates pipeline functionality starting from the variant calling step
     
@@ -585,7 +644,7 @@ nextflow_pipeline {
     Success Criteria: VCF precision ≥99% vs reference
     ========================================================================================
     */
-    test("TEST 8. Intermediate step - Calling entry point") {
+    test("TEST 9. Intermediate step - Calling entry point") {
         tag "calling"
 
         when {
@@ -629,7 +688,7 @@ nextflow_pipeline {
                 assert output.isNumber() : "COMPARISON SCRIPT ERROR: Non-numeric output from compare_vcfs_detailed.py for ${currentVcf.name}: '${output}'"
                 def precision = output as Double
 
-                println "\n[TEST 8 - CALLING STEP] VCF precision for ${currentVcf.name}: ${precision}%"
+                println "\n[TEST 9 - CALLING STEP] VCF precision for ${currentVcf.name}: ${precision}%"
                 assert precision >= 99.0 : "PRECISION FAILURE: VCF ${currentVcf.name} precision ${precision}% below 99% threshold"
             }
         }
@@ -637,7 +696,7 @@ nextflow_pipeline {
 
     /*
     ========================================================================================
-        TEST 9: INTERMEDIATE STEP - Unmapped Consensus Step Entry Point
+        TEST 10: INTERMEDIATE STEP - Unmapped Consensus Step Entry Point
     ========================================================================================
     Purpose: Validates pipeline functionality starting from the unmapped consensus step
     
@@ -666,7 +725,7 @@ nextflow_pipeline {
     Success Criteria: VCF precision ≥99% vs reference
     ========================================================================================
     */
-    test("TEST 9. Intermediate step - Unmapped Consensus entry point") {
+    test("TEST 10. Intermediate step - Unmapped Consensus entry point") {
         tag "unmapped_consensus"
 
         when {
@@ -712,7 +771,7 @@ nextflow_pipeline {
                 assert output.isNumber() : "COMPARISON SCRIPT ERROR: Non-numeric output from compare_vcfs_detailed.py for ${currentVcf.name}: '${output}'"
                 def precision = output as Double
 
-                println "\n[TEST 9 - UNMAPPED CONSENSUS STEP] VCF precision for ${currentVcf.name}: ${precision}%"
+                println "\n[TEST 10 - UNMAPPED CONSENSUS STEP] VCF precision for ${currentVcf.name}: ${precision}%"
                 assert precision >= 99.0 : "PRECISION FAILURE: VCF ${currentVcf.name} precision ${precision}% below 99% threshold"
             }
         }
@@ -720,7 +779,7 @@ nextflow_pipeline {
 
     /*
     ========================================================================================
-        TEST 10: INTERMEDIATE STEP - All Molecules File Step Entry Point
+        TEST 11: INTERMEDIATE STEP - All Molecules File Step Entry Point
     ========================================================================================
     Purpose: Validates pipeline functionality for generating all molecules file metrics
     
@@ -749,7 +808,7 @@ nextflow_pipeline {
     Success Criteria: VCF precision ≥99% vs reference
     ========================================================================================
     */
-    test("TEST 10. Intermediate step - All Molecules File entry point") {
+    test("TEST 11. Intermediate step - All Molecules File entry point") {
         tag "allmoleculesfile"
 
         when {
@@ -795,7 +854,7 @@ nextflow_pipeline {
                 assert output.isNumber() : "COMPARISON SCRIPT ERROR: Non-numeric output from compare_vcfs_detailed.py for ${currentVcf.name}: '${output}'"
                 def precision = output as Double
 
-                println "\n[TEST 10 - ALL MOLECULES FILE STEP] VCF precision for ${currentVcf.name}: ${precision}%"
+                println "\n[TEST 11 - ALL MOLECULES FILE STEP] VCF precision for ${currentVcf.name}: ${precision}%"
                 assert precision >= 99.0 : "PRECISION FAILURE: VCF ${currentVcf.name} precision ${precision}% below 99% threshold"
             }
         }

--- a/workflows/deepumicaller.nf
+++ b/workflows/deepumicaller.nf
@@ -189,24 +189,33 @@ workflow DEEPUMICALLER {
         
         ch_multiqc_files = ch_multiqc_files.mix(FASTQC.out.zip.collect{it -> it[1]}.ifEmpty([]))
 
-        // // Optional: Include fastqs split
-        // if (params.run_splitfastq) {
-        //     SPLITFASTQ ( reads_to_qc )
-        //     SPLITFASTQ.out.split_fastqs
-        //     .transpose()
-        //     .map { meta, fastqs -> 
-        //         def new_meta = meta.clone()
-        //         // Extract part ID from FASTQ filename using regex, e.g. "sample1_L001_R1_001.fastq.gz" -> "sample1"
-        //         def match = fastqs[0].name =~ /^([^. _-]+)/
-        //         def part_id = match ? match[0][1] : "unknown"
-        //         new_meta.id = "${meta.id}_${part_id}"
-        //         [new_meta, fastqs]
-        //     }
-        //     .set { split_fastqs_ch }
-        // } else {
-        //     split_fastqs_ch = reads_to_qc
-        // }
-        split_fastqs_ch = reads_to_qc
+        // Optional: Split FASTQs into parts for parallelisation
+        if (params.run_splitfastq) {
+            SPLITFASTQ ( reads_to_qc )
+            SPLITFASTQ.out.split_fastqs
+                .flatMap { meta, files ->
+                    // Group files by part number (seqkit names them *.part_NNN.*)
+                    def byPart = [:]
+                    files.each { f ->
+                        def m = (f.name =~ /\.part_(\d+)\./)
+                        if (m) {
+                            def part = m[0][1]
+                            if (!byPart[part]) byPart[part] = []
+                            byPart[part] << f
+                        }
+                    }
+                    // Emit one [meta, [R1, R2]] tuple per part; sort files so R1 precedes R2
+                    byPart.sort { a, b -> a.key <=> b.key }.collect { part, partFiles ->
+                        def new_meta = meta.clone()
+                        new_meta.id = "${meta.id}_part${part}"
+                        // meta.sample is preserved so MERGEBAM can group parts back together
+                        [new_meta, partFiles.sort { f -> f.name }]
+                    }
+                }
+                .set { split_fastqs_ch }
+        } else {
+            split_fastqs_ch = reads_to_qc
+        }
 
         FASTQTOBAM(split_fastqs_ch)
 
@@ -234,9 +243,15 @@ workflow DEEPUMICALLER {
             ch_multiqc_files = ch_multiqc_files.mix(QUALIMAPQCRAW.out.results.map{it -> it[1]}.collect())
         }
 
+        // When FASTQs were split internally, all resulting BAMs must be merged regardless
+        // of whether the original samplesheet indicated pre-split input
+        def ch_is_split = params.run_splitfastq ?
+            channel.value(true) :
+            INPUT_CHECK.out.splitted_input
+
         // Combine sorted BAMs with the flag and branch
         SORTBAMRAW.out.bam
-            .combine(INPUT_CHECK.out.splitted_input)
+            .combine(ch_is_split)
             .branch { meta, bam, flag ->
                 split: flag == true
                     return tuple(meta, bam)


### PR DESCRIPTION
# Enable internal FASTQ splitting via seqkit split2
The pipeline already had a SPLITFASTQ module (seqkit split2) and its associated parameters (run_splitfastq, splitfastq_parts), but the workflow block was commented out as "not fully tested" since March 2026.

### What was wrong
The original implementation used .transpose() to split the output channel, which produced individual single-file tuples instead of proper [meta, [R1, R2]] pairs. This would have caused FASTQTOBAM to receive unpaired reads and fail.

Additionally, there was no mechanism to force the existing BAM merge step (MERGEBAM) to run when FASTQs were split internally.

## Changes
workflows/deepumicaller.nf: Reactivated the SPLITFASTQ block using .flatMap to correctly reconstruct R1/R2 pairs grouped by part number (*.part_NNN.*). Added a ch_is_split channel that forces the merge path when run_splitfastq = true, so all split BAMs are merged back per sample before UMI grouping.

modules/local/splitfastq/main.nf: Removed the hardcoded ?: 10 fallback for split_parts; the value always comes from params.splitfastq_parts (default 5 in nextflow.config).

nextflow_schema.json: Removed hidden: true from run_splitfastq and splitfastq_parts, making both parameters visible and configurable from Seqera Platform.

tests/main.nf.test: Added TEST 2 (tag: split_fastq) which runs the same input as TEST 1 with run_splitfastq = true and splitfastq_parts = 2, validating that split + merge produces identical VCF output (≥99% precision vs reference). Previous tests renumbered 3–11.