### PR TITLE
update proportion of Ns per read with trimming

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -188,7 +188,6 @@ process {
         ext.fgbio_args      = " --min-reads ${params.filter_min_reads_am} \
                                 --min-base-quality ${params.filter_min_baseq_am} \
                                 --max-base-error-rate ${params.filter_max_base_error_rate_am} \
-                                --max-no-call-fraction ${params.maxN_prop_per_read} \
                                 --require-single-strand-agreement false"
         publishDir       = [
                 enabled : false
@@ -199,7 +198,6 @@ process {
         ext.fgbio_args      = " --min-reads ${params.filter_min_reads_duplex} \
                                 --min-base-quality ${params.filter_min_baseq_duplex} \
                                 --max-base-error-rate ${params.filter_max_base_error_rate_duplex} \
-                                --max-no-call-fraction ${params.maxN_prop_per_read} \
                                 --require-single-strand-agreement ${params.filter_strand_agreement}"
         publishDir       = [
                 enabled : false

--- a/modules/local/fgbio/filterconsensusreads/main.nf
+++ b/modules/local/fgbio/filterconsensusreads/main.nf
@@ -17,7 +17,8 @@ process FGBIO_FILTERCONSENSUSREADS {
 
     script:
     def fgbio_args = task.ext.fgbio_args ?: ''
-    // def samtools_args = task.ext.samtools_args ?: ''
+    def Ns_per_read = (params.maxN_per_read + params.left_clip + params.right_clip) / params.read_length_minus_tag
+    def max_no_call_fraction = Ns_per_read ? "--max-no-call-fraction ${Ns_per_read}" : "--max-no-call-fraction 0.2"
     def prefix = task.ext.prefix ?: ""
     prefix = "${meta.id}${prefix}"
     def mem_gb = 8
@@ -26,22 +27,8 @@ process FGBIO_FILTERCONSENSUSREADS {
     } else {
         mem_gb = task.memory.giga
     }
-    // sort = false
-    // if (sort) {
-    //     fgbio_zipper_bams_output = "/dev/stdout"
-    //     fgbio_zipper_bams_compression = 0 // do not compress if samtools is consuming it
-    //     extra_command = " | samtools sort "
-    //     extra_command += samtools_sort_args
-    //     extra_command += " --template-coordinate"
-    //     extra_command += " --threads "+ task.cpus
-    //     extra_command += " -o " + prefix + ".filtered.bam##idx##"+ prefix + ".filtered.bam.bai"
-    //     extra_command += " --write-index"
-    //     extra_command += samtools_args
-    // } else {
     fgbio_zipper_bams_output = prefix + ".filtered.bam"
     fgbio_zipper_bams_compression = 1
-    // extra_command = ""
-    // }
     """
     fgbio \\
         -Xmx${mem_gb}g \\
@@ -51,7 +38,8 @@ process FGBIO_FILTERCONSENSUSREADS {
         --input $grouped_bam \\
         --ref ${fasta} \\
         --output ${fgbio_zipper_bams_output} \\
-        $fgbio_args;
+        ${max_no_call_fraction} \\
+        ${fgbio_args};
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
@@ -59,34 +47,3 @@ process FGBIO_FILTERCONSENSUSREADS {
     END_VERSIONS
     """
 }
-
-// --max-base-error-rate ${max_base_error_rate} \\
-
-// min-reads	M	Int	The minimum number of reads supporting a consensus base/read.	Required	3	 
-// min-base-quality	N	PhredScore	Mask (make N) consensus bases with quality less than this threshold.	Required	1	 
-// max-base-error-rate	e	Double	The maximum error rate for a single consensus base.	Required	3	0.1
-
-// min-reads 3 1 1 
-// min-base-quality 10
-// max-base-error-rate 0.1
-
-// min-reads	M	Int	The minimum number of reads supporting a consensus base/read.	Required	3	 
-// min-base-quality	N	PhredScore	Mask (make N) consensus bases with quality less than this threshold.	Required	1	 
-// max-read-error-rate	E	Double	The maximum raw-read error rate across the entire consensus read.	Required	3	0.025
-// max-base-error-rate	e	Double	The maximum error rate for a single consensus base.	Required	3	0.1
-// max-no-call-fraction	n	Double	Maximum fraction of no-calls in the read after filtering.	Optional	1	0.2
-// min-mean-base-quality	q	PhredScore	The minimum mean base quality across the consensus read.	Optional	1	 
-// require-single-strand-agreement	s	Boolean	Mask (make N) consensus bases where the AB and BA consensus reads disagree (for duplex-sequencing only).	Optional	1	false
-
-// min-reads                3 1 1
-// min-base-quality         10
-// max-read-error-rate      0.025
-// max-base-error-rate      0.1 0.3 0.3
-// max-no-call-fraction     0.2
-// min-mean-base-quality    20 // 
-// require-single-strand-agreement	true
-
-
-// --min-reads ${min_reads} \\
-// --min-base-quality ${min_baseq} \\
-// --max-base-error-rate 0.2 0.05 0.4 \\

--- a/nextflow.config
+++ b/nextflow.config
@@ -70,8 +70,9 @@ params {
     
     
     // filterconsensusreads
-    maxN_prop_per_read              = 0.2                 // reads with higher proportion of Ns will be discarded from the BAM file
-    filter_strand_agreement         = true                // require both strands to agree in determining a base
+    maxN_per_read                   = 15            // reads with more than these many Ns will be discarded from the BAM file
+    filter_strand_agreement         = true          // require both strands to agree in determining a base
+    read_length_minus_tag           = 142           // size of the reads after removing UMI
 
     // filterconsensusreads all_molecules
     filter_min_reads_am             = "2 1 0"        // default minimum input reads for fgbio's FILTERCONSENSUSREADS

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -206,11 +206,11 @@
             "fa_icon": "fas fa-dna",
             "description": "Options for when filtering consensus reads",
             "properties": {
-                "maxN_prop_per_read": {
+                "maxN_per_read": {
                     "type": "number",
-                    "description": "The maximum proportion of Ns in a consensus read",
+                    "description": "The maximum number of Ns in a consensus read",
                     "fa_icon": "fas fa-book",
-                    "help_text": "The maximum proportion of Ns in a consensus read for it to be kept when filtering using fgbio's FilterConsensusReads."
+                    "help_text": "The maximum number of Ns in a consensus read for it to be kept when filtering using fgbio's FilterConsensusReads."
                 },
                 "filter_strand_agreement": {
                     "type": "boolean",
@@ -401,6 +401,13 @@
                     "default": 150,
                     "fa_icon": "fas fa-book",
                     "help_text": "Parameter to define the maximum read size."
+                },
+                "read_length_minus_tag": {
+                    "type": "integer",
+                    "description": "Size of the reads after removing UMI.",
+                    "default": 142,
+                    "fa_icon": "fas fa-book",
+                    "help_text": "Size of the reads after removing UMI."
                 }
             }
         },


### PR DESCRIPTION
- fix #189 
  - this was a problem when applying a lot of trimming and now it should work well
- added new parameters to control the filtering process and to define the length of the read based on which we compute the proportion of Ns for filtering


## AI summary

This pull request updates how the pipeline filters consensus reads by switching from a proportion-based to a count-based threshold for ambiguous bases (Ns) per read. The changes ensure that reads are filtered based on the maximum number of Ns rather than their proportion, and introduce a new parameter to account for read length after removing tags. This improves clarity and control over filtering criteria.

**Consensus read filtering parameter changes:**

* Replaced the `maxN_prop_per_read` parameter (proportion of Ns allowed per read) with `maxN_per_read` (maximum number of Ns allowed per read) in `nextflow.config` and `nextflow_schema.json`, updating descriptions and help text accordingly. [[1]](diffhunk://#diff-ce7465a8e67b3b9c95696db1146ca7e6328f075e08a3d64062b87aa8608fc4eaL73-R75) [[2]](diffhunk://#diff-4ec6c97fca07ea9b1ff300c0c4488d0f097ae32a78f0e0b01e00b9df0c346eb6L209-R213)
* Added a new `read_length_minus_tag` parameter to specify the read length after removing UMI tags, with default and documentation in `nextflow.config` and `nextflow_schema.json`. [[1]](diffhunk://#diff-ce7465a8e67b3b9c95696db1146ca7e6328f075e08a3d64062b87aa8608fc4eaL73-R75) [[2]](diffhunk://#diff-4ec6c97fca07ea9b1ff300c0c4488d0f097ae32a78f0e0b01e00b9df0c346eb6R404-R410)

**Pipeline logic updates:**

* Removed direct passing of `--max-no-call-fraction` from `conf/modules.config` and instead calculated it dynamically in `modules/local/fgbio/filterconsensusreads/main.nf` using the new `maxN_per_read` and `read_length_minus_tag` parameters. [[1]](diffhunk://#diff-bf809c928cb10b54d251dec8a140a2d5505150f97175d8d7b51dda9cc57971feL191) [[2]](diffhunk://#diff-bf809c928cb10b54d251dec8a140a2d5505150f97175d8d7b51dda9cc57971feL202) [[3]](diffhunk://#diff-ed5aacf5dc637550e9ae3c47ed42dd4067ff5371bca627a929aa93ffca6d0fefL20-R21)
* Updated the script in `modules/local/fgbio/filterconsensusreads/main.nf` to compute and append the correct `--max-no-call-fraction` value based on the new parameters. [[1]](diffhunk://#diff-ed5aacf5dc637550e9ae3c47ed42dd4067ff5371bca627a929aa93ffca6d0fefL20-R21) [[2]](diffhunk://#diff-ed5aacf5dc637550e9ae3c47ed42dd4067ff5371bca627a929aa93ffca6d0fefL54-L92)

**Code cleanup:**

* Removed commented-out or obsolete code related to the old filtering approach and unused variables in `modules/local/fgbio/filterconsensusreads/main.nf`. [[1]](diffhunk://#diff-ed5aacf5dc637550e9ae3c47ed42dd4067ff5371bca627a929aa93ffca6d0fefL29-L44) [[2]](diffhunk://#diff-ed5aacf5dc637550e9ae3c47ed42dd4067ff5371bca627a929aa93ffca6d0fefL54-L92)